### PR TITLE
feat: allow specifying libraries to skip

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -26,7 +26,7 @@ class Settings(BaseSettings):
     library_index_refresh_interval: int = 3600
     ignored_libraries: list[str] = [
         ""
-    ]  # Libraries that should be ignored when downloading them. Useful for testing with unpublished changes to libraries
+    ] # Libraries that should be ignored when downloading them, for testing unpublished changes to libraries
 
     # Max number of concurrent compile tasks
     max_concurrent_tasks: int = 10

--- a/conf.py
+++ b/conf.py
@@ -23,6 +23,7 @@ class Settings(BaseSettings):
     max_library_caches: int = 50
     library_cache_duration: int = 24 * 3600
     library_index_refresh_interval: int = 3600
+    ignored_libraries: list[str] = [] # Libraries that should be ignored when downloading them. Useful for testing with unpublished changes to libraries
 
     # Max number of concurrent compile tasks
     max_concurrent_tasks: int = 10

--- a/conf.py
+++ b/conf.py
@@ -10,6 +10,7 @@ class Settings(BaseSettings):
 
     arduino_cli_path: str = "arduino-cli"
     cors_origins: list[str] = ["*"]
+    cors_origin_regex: str | None = None
     log_level: str = "INFO"
 
     # Session settings

--- a/conf.py
+++ b/conf.py
@@ -23,7 +23,9 @@ class Settings(BaseSettings):
     max_library_caches: int = 50
     library_cache_duration: int = 24 * 3600
     library_index_refresh_interval: int = 3600
-    ignored_libraries: list[str] = [] # Libraries that should be ignored when downloading them. Useful for testing with unpublished changes to libraries
+    ignored_libraries: list[str] = [
+        ""
+    ]  # Libraries that should be ignored when downloading them. Useful for testing with unpublished changes to libraries
 
     # Max number of concurrent compile tasks
     max_concurrent_tasks: int = 10

--- a/main.py
+++ b/main.py
@@ -42,6 +42,10 @@ async def _install_libraries(libraries: list[Library]) -> None:
         if library_cache.get(library):
             continue
 
+        if library in settings.ignored_libraries:
+            logger.warning("Ignoring library: %s", library)
+            continue
+        
         logger.info("Installing libraries: %s", library)
         installer = await asyncio.create_subprocess_exec(
             settings.arduino_cli_path,

--- a/main.py
+++ b/main.py
@@ -45,7 +45,7 @@ async def _install_libraries(libraries: list[Library]) -> None:
         if library in settings.ignored_libraries:
             logger.warning("Ignoring library: %s", library)
             continue
-        
+
         logger.info("Installing libraries: %s", library)
         installer = await asyncio.create_subprocess_exec(
             settings.arduino_cli_path,

--- a/main.py
+++ b/main.py
@@ -23,6 +23,7 @@ app = FastAPI(lifespan=startup)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.cors_origins,
+    allow_origin_regex=settings.cors_origin_regex,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
This pull request introduces a new feature to block specific libraries during the download process, which can be useful for testing with unpublished changes to libraries.

### New Feature: Ignoring Specific Libraries

* [`conf.py`](diffhunk://#diff-6e03d3d89630aba3403afea3514a3ac5948e70d1ced091012e56446f614da340R26): Added a new setting `ignored_libraries` to the `Settings` class, which is a list of libraries that should be ignored when downloading.

* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R45-R48): Updated the `_install_libraries` function to check if a library is in the `ignored_libraries` list and log a warning message if it is ignored.