### PR TITLE
fix: pre-install all platforms at startup

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -23,8 +23,7 @@ class Settings(BaseSettings):
     max_code_caches: int = 100
     code_cache_duration: int = 3600
     max_library_caches: int = 50
-    library_cache_duration: int = 24 * 3600
-    library_index_refresh_interval: int = 3600
+    library_cache_duration: int = 365 * 24 * 3600
 
     # Max number of concurrent compile tasks
     max_concurrent_tasks: int = 10

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 RUN apt-get -y update && apt-get -y install dumb-init curl && apt-get clean
 

--- a/deps/sketch.py
+++ b/deps/sketch.py
@@ -37,6 +37,7 @@ async def install_libraries(libraries: list[Library], fqbn: str):
         raise HTTPException(422, "Unsupported fqbn")
     pio_environment = fqbn_to_board[fqbn]
     for library in libraries:
+        logger.info("Installing library %s in environment %s", library, pio_environment)
         if library_cache.get(library + pio_environment):
             continue
         installer = await asyncio.create_subprocess_exec(
@@ -123,13 +124,28 @@ async def setup_platformio() -> None:
         ) as platform_ini:
             await platform_ini.write(
                 platformio_ini_text
-                + f"\n[platformio]\nsrc_dir = src{task_num}\nbuild_dir = build{task_num}"
+                + f"\n[platformio]\nsrc_dir = src{task_num}\nbuild_dir = build{task_num}\n"
             )
     # Make platformio.ini
     async with aiofiles.open(
         f"{settings.platformio_data_dir}/platformio.ini", "w+"
     ) as default_platform_ini:
         await default_platform_ini.write(platformio_ini_text)
+
+    # Per-install all supported platforms
+    logger.info("Pre-installing all platforms, this will take a while...")
+    install = await asyncio.create_subprocess_exec(
+        "platformio",
+        "-c",
+        "platformio.ini",
+        "pkg",
+        "install",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=settings.platformio_data_dir,
+    )
+    stdout, stderr = await install.communicate()
+    logger.info("Pre-installed all platforms:\n %s, %s", stdout.decode(), stderr.decode())
 
 
 @asynccontextmanager

--- a/deps/sketch.py
+++ b/deps/sketch.py
@@ -145,7 +145,9 @@ async def setup_platformio() -> None:
         cwd=settings.platformio_data_dir,
     )
     stdout, stderr = await install.communicate()
-    logger.info("Pre-installed all platforms:\n %s, %s", stdout.decode(), stderr.decode())
+    logger.info(
+        "Pre-installed all platforms:\n %s, %s", stdout.decode(), stderr.decode()
+    )
 
 
 @asynccontextmanager

--- a/main.py
+++ b/main.py
@@ -50,7 +50,7 @@ async def compile_cpp(sketch: Sketch, session_id: Session) -> dict[str, str]:
             await install_libraries(sketch.libraries, sketch.board)
             result = await compile_sketch(sketch, task_id)
             code_cache[cache_key] = result
-            available_task_ids.append(task_id)
+            available_task_ids.insert(0, task_id)
             return result
     finally:
         compile_sessions[session_id] -= 1


### PR DESCRIPTION
fix: always start at the lowest build task id
chore: add some info logging